### PR TITLE
Fix pyyaml version conflict

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['sagemaker_tools', 'sage_extensions'],
     install_requires=[
         'boto3',
-        'pyyaml>=4.2b1',
+        'pyyaml<4.3,>=4.2b1',
         'sagemaker',
         'slackweb'],
     entry_points={


### PR DESCRIPTION
setup.py の pyyaml のバージョンを 4.3 より低くしました。
変更前の setup.py でインストールすると、 pyyaml の最新バージョンがインストールされますが、
sagemaker-python-sdk で必要な docker compose が pyyaml < 4.3 を要求しているため、
バージョンの衝突が生じていました。
`smtrain` を実行しようとすると、バージョンの衝突のエラーが出てしまい、実行できませでした。
setup.py に `pyyaml < 4.3` を追記することで、実行できるようにしました。